### PR TITLE
feat(json-detail): implement support for GeoJSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "store2": "^2.12.0",
     "use-query-params": "^1.2.2",
     "vite-plugin-rewrite-all": "^0.1.2",
+    "wkt": "^0.1.1",
     "wretch": "^1.7.4",
     "yaml": "^1.10.0",
     "yup": "^0.32.9"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "d3-dsv": "^2.0.0",
     "date-fns": "^2.19.0",
     "downshift": "^6.1.0",
+    "flat": "^5.0.2",
     "formik": "^2.2.6",
     "lodash": "^4.17.21",
     "lodash.debounce": "^4.0.8",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@octokit/types": "^6.12.2",
     "@tailwindcss/forms": "^0.2.1",
+    "@types/flat": "^5.0.1",
     "@types/nprogress": "^0.2.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,6 +678,11 @@
   dependencies:
     "@types/trusted-types" "*"
 
+"@types/flat@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/flat/-/flat-5.0.1.tgz#9d703bbfb59ad9ec9ce376bdeb93a0f85da27059"
+  integrity sha512-ykRODHi9G9exJdTZvQggsqCUtB7jqiwLHcXCjNMb7zgWx6Lc2bydIUYBG1+It6VXZVFaeROv6HqPjDCAsoPG3w==
+
 "@types/history@*":
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
@@ -1512,6 +1517,11 @@ filter-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
   integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
+flat@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
+  integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 formik@^2.2.6:
   version "2.2.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,6 +2749,11 @@ warning@^4.0.2, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
+wkt@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/wkt/-/wkt-0.1.1.tgz#8d3280cb0d7664343d8987a30c85806554618bf8"
+  integrity sha512-2vtzYZOqN0VZdtDTMDUgbpXpE+MXRdsFTiCpS08FZ4yktT9pPylVMZaLxcIqT9pRkBp5FIAGVQyJ/kJa9b8uGg==
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10572368/121798382-8fff6580-cc58-11eb-943f-8d893b45f38e.png)

## Problem

Fixes #12 

## Solution

If the parsed result of a .json or .geojson is a collection of
GeoJSON Geometries or Features, flatten the result into an
array of such objects, flattening the nesting in each Feature for
easier viewing in the grid.

- `yarn add flat wkt`
- implement `handleJSONOrGeoJSON()`, a function that will
  parse a string into JSON, determine if the content is GeoJSON,
  and if so, do one of the following:
  - if the result is a FeatureCollection or an array of Features,
    take the array (`FeatureCollection.features` or the array itself),
    flatten each Feature (notably `geometry` and `properties`), and
    return the result with well-known text and point longlat where suitable
  - if the result is a GeometryCollection or an array of Geometries, 
    return the array of geometries, adding well-known text and point longlat
  - otherwise, just return the parsed result as-is
- use `handleJSONOrGeoJSON()` to parse .json and .geojson files

This implementation is inspired in part by GitHub's own [documentation
for mapping GeoJSON](https://docs.github.com/en/github/managing-files-in-a-repository/working-with-non-code-files/mapping-geojson-files-on-github).

## Testing

Use https://flatgithub.com/datascapesg/help-our-hawkers as a test case

