### PR TITLE
fix(json-detail): set `hasMounted` false on filename change

### DIFF
--- a/src/components/json-detail-container.tsx
+++ b/src/components/json-detail-container.tsx
@@ -98,6 +98,7 @@ export function JSONDetail(props: JSONDetailProps) {
 
   React.useEffect(() => {
     if (!hasMounted) return;
+    setHasMounted(false);
 
     setQuery(
       {


### PR DESCRIPTION
## Problem

When the filename changes, the sort, stickyColumnName and filters 
fields in `setQuery()` are reset. However, the change in data triggers
`onGridChange()`, which sets the aforementioned fields to their former
values. This triggers an oscillation involving `onGridChange()` as the
grid switches between two different query states.

## Solution

If there is a change in filename, we anticipate a change in the grid
data, and hence should set `hasMounted` false since in effect, we have
unmounted. This prevents `onGridChange()` trying to undo the sort,
stickyColumnName and filters reset, since it can only do so when
hasMounted is true.