### PR TITLE
feat: list repos tagged "flat-data" in a specific organization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryParamProvider } from "use-query-params";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 
 import { RepoDetail } from "./components/repo-detail";
+import { OrgListing } from "./components/org-listing";
 import { Home } from "./components/home";
 import { useProgressBar } from "./hooks";
 
@@ -20,6 +21,7 @@ function App() {
         <QueryParamProvider ReactRouterRoute={Route}>
           <Switch>
             <Route exact path="/" component={Home} />
+            <Route exact path="/:org/" component={OrgListing} />
             <Route path="/:owner/:name" component={RepoDetail} />
           </Switch>
         </QueryParamProvider>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,7 +3,7 @@ import { Endpoints } from "@octokit/types";
 import store from "store2";
 import YAML from "yaml";
 
-import { Repo } from "../types";
+import { Repo, Repository } from "../types";
 import { csvParse, tsvParse } from "d3-dsv";
 
 export type listCommitsResponse =
@@ -52,7 +52,15 @@ const getFilesFromRes = (res: any) => {
     .map((file: any) => file.path)
     .filter((path: string) => {
       const extension = path.split(".").pop() || "";
-      const validExtensions = ["csv", "tsv", "json", "geojson", "topojson", "yml", "yaml"];
+      const validExtensions = [
+        "csv",
+        "tsv",
+        "json",
+        "geojson",
+        "topojson",
+        "yml",
+        "yaml",
+      ];
       return (
         validExtensions.includes(extension) &&
         !ignoredFiles.includes(path.split("/").slice(-1)[0]) &&
@@ -129,7 +137,15 @@ export function fetchDataFile(params: FileParamsWithSHA) {
   const { filename, name, owner, sha } = params;
   if (!filename) return [];
   const fileType = filename.split(".").pop() || "";
-  const validTypes = ["csv", "tsv", "json", "geojson", "topojson", "yml", "yaml"];
+  const validTypes = [
+    "csv",
+    "tsv",
+    "json",
+    "geojson",
+    "topojson",
+    "yml",
+    "yaml",
+  ];
   if (!validTypes.includes(fileType)) return [];
 
   return wretch()
@@ -145,24 +161,27 @@ export function fetchDataFile(params: FileParamsWithSHA) {
       try {
         if (fileType === "csv") {
           data = csvParse(res);
-        } else if (["geojson", "topojson"].includes(fileType) || filename.endsWith(".geo.json")) {
+        } else if (
+          ["geojson", "topojson"].includes(fileType) ||
+          filename.endsWith(".geo.json")
+        ) {
           data = JSON.parse(res);
           if (data.features) {
             const features = data.features.map((feature: any) => {
-              let geometry = {} as Record<string, any>
-              Object.keys(feature?.geometry).forEach(key => {
+              let geometry = {} as Record<string, any>;
+              Object.keys(feature?.geometry).forEach((key) => {
                 geometry[`geometry.${key}`] = feature.geometry[key];
-              })
-              let properties = {} as Record<string, any>
-              Object.keys(feature?.properties).forEach(key => {
+              });
+              let properties = {} as Record<string, any>;
+              Object.keys(feature?.properties).forEach((key) => {
                 properties[`properties.${key}`] = feature.properties[key];
-              })
-              const {geometry: g, properties: p, ...restOfKeys} = feature;
-              return {...restOfKeys, ...geometry, ...properties};
-            })
+              });
+              const { geometry: g, properties: p, ...restOfKeys } = feature;
+              return { ...restOfKeys, ...geometry, ...properties };
+            });
             // make features the first key of the object
-            const { features: f, ...restOfData } = data
-            data = { features, ...restOfData }
+            const { features: f, ...restOfData } = data;
+            data = { features, ...restOfData };
           }
         } else if (fileType === "json") {
           data = JSON.parse(res);
@@ -244,6 +263,16 @@ export function fetchDataFile(params: FileParamsWithSHA) {
         },
       ];
     });
+}
+
+export async function fetchOrgRepos(orgName: string) {
+  const res = await githubWretch
+    .url(`/search/repositories`)
+    .query({ q: `topic:flat-data org:${orgName}`, per_page: 100 })
+    .get()
+    .json();
+
+  return res.items;
 }
 
 const stringifyValue = (data: any) => {

--- a/src/components/org-listing.tsx
+++ b/src/components/org-listing.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { RouteComponentProps } from "react-router";
+import { Link } from "react-router-dom";
+import formatDistance from "date-fns/formatDistance";
+import { GoStar } from "react-icons/go";
+
+import { useOrgFlatRepos } from "../hooks";
+import { ErrorState } from "./error-state";
+import { Spinner } from "./spinner";
+import Bug from "../bug.svg";
+import { Repository } from "../types";
+
+interface OrgListingProps extends RouteComponentProps<{ org: string }> {}
+
+interface RepoListingProps {
+  repos: Repository[];
+  org: string;
+}
+
+function RepoListing(props: RepoListingProps) {
+  return (
+    <ul className="divide-y rounded-xl overflow-hidden">
+      {props.repos.map((repo) => {
+        const lastUpdated = formatDistance(
+          Date.parse(repo.updated_at),
+          new Date(),
+          {
+            addSuffix: true,
+          }
+        );
+
+        return (
+          <li className="bg-white hover:bg-opacity-70" key={repo.name}>
+            <Link className="p-4 block" to={`/${props.org}/${repo.name}`}>
+              <span className="text-indigo-600 font-medium">
+                {props.org}/{repo.name}
+              </span>
+              <div className="mt-1 mb-2 text-lg">
+                <p>{repo.description}</p>
+              </div>
+              <ul className="flex items-center space-x-3 text-sm text-gray-600">
+                <li className="flex space-x-1 items-center">
+                  <GoStar className="text-gray-400" />
+                  <span>{repo.stargazers_count}</span>
+                </li>
+                <li>{repo.language}</li>
+                {Boolean(repo.license) && <li>{repo.license.name}</li>}
+                <li>Updated {lastUpdated}</li>
+              </ul>
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function OrgListing(props: OrgListingProps) {
+  const { match } = props;
+  const { org } = match.params;
+  const { data = [], status } = useOrgFlatRepos(org);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-4 bg-indigo-600 flex-shrink-0">
+        <header className="flex justify-between items-center">
+          <div className="text-indigo-100 font-light text-sm">
+            <strong className="font-bold">Flat Viewer</strong> a simple tool for
+            exploring flat data files in GitHub repositories.
+          </div>
+        </header>
+      </div>
+      {status === "loading" && (
+        <div className="flex items-center justify-center h-full">
+          <div className="max-w-sm flex items-center justify-center space-x-4">
+            <Spinner />
+            <p>Loading organization...</p>
+          </div>
+        </div>
+      )}
+      {status === "success" &&
+        (data.length > 0 ? (
+          <div className="p-4 overflow-scroll">
+            <div className="mb-4">
+              Repositories tagged{" "}
+              <span className="bg-indigo-600 text-white text-xs p-1 rounded">
+                flat-data
+              </span>{" "}
+              in the <span className="font-medium">{org}</span> organization.
+            </div>
+            <RepoListing repos={data} org={org} />
+          </div>
+        ) : (
+          <ErrorState img={Bug} alt="Bug icon">
+            <div className="max-w-sm mx-auto">
+              Hmm, we couldn't find any repos with the topic{" "}
+              <span className="bg-indigo-600 text-white text-xs p-1 rounded">
+                flat-data
+              </span>{" "}
+              in this organization
+            </div>
+          </ErrorState>
+        ))}
+      {status === "error" && (
+        <div className="flex items-center justify-center h-full">
+          <ErrorState img={Bug} alt="Bug icon">
+            Hmm, we could not load the organization.
+          </ErrorState>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,8 +9,9 @@ import {
   FileParamsWithSHA,
   listCommitsResponse,
   fetchFilesFromRepo,
+  fetchOrgRepos,
 } from "../api";
-import { Repo, FlatDataTab } from "../types";
+import { Repo, FlatDataTab, Repository } from "../types";
 import React from "react";
 
 // Hooks
@@ -69,4 +70,15 @@ export function useGetFiles(
       ...config,
     }
   );
+}
+
+export function useOrgFlatRepos(
+  orgName: string,
+  config?: UseQueryOptions<Repository[]>
+) {
+  return useQuery(["org", orgName], () => fetchOrgRepos(orgName), {
+    retry: false,
+    refetchOnWindowFocus: false,
+    ...config,
+  });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import { Endpoints } from "@octokit/types";
 
-export type Commit = Endpoints["GET /repos/{owner}/{repo}/commits"]["response"]["data"][0];
+export type Commit =
+  Endpoints["GET /repos/{owner}/{repo}/commits"]["response"]["data"][0];
 
 export type Repo = {
   owner: string;
@@ -11,4 +12,21 @@ export interface FlatDataTab {
   key?: string;
   value?: object[];
   invalidValue?: string;
+}
+
+interface RepositoryLicense {
+  key: string;
+  name: string;
+  url: string;
+}
+
+export interface Repository {
+  name: string;
+  description: string;
+  id: string;
+  topics?: string[];
+  stargazers_count: number;
+  language: string;
+  updated_at: string;
+  license: RepositoryLicense;
 }


### PR DESCRIPTION
Resolves https://github.com/githubocto/flat-viewer/issues/24.

Specifically, this PR exposes a new client-side route `/:org`. When the component loads, it immediately triggers a request to the GitHub API's search endpoint to find any repositories tagged with `flat-data`.

The results are rendered accordingly, and each result links directly to a Flat Viewer page.

```tsx
const res = await githubWretch
  .url(`/search/repositories`)
  .query({ q: `topic:flat-data org:${orgName}`, per_page: 100 })
  .get()
  .json();
```

**Success State**
<img width="1136" alt="Screen Shot 2021-07-26 at 2 58 22 PM" src="https://user-images.githubusercontent.com/5148596/127043942-266b5b9d-87b0-404a-a846-79afe07caa6f.png">


**Error State (request was successful, but no repos found)**
<img width="501" alt="Screen Shot 2021-07-26 at 2 44 31 PM" src="https://user-images.githubusercontent.com/5148596/127043857-b8d53e3f-ea18-4f27-a2ba-ebaa7f95b808.png">

**Error State (could not find the org)**
<img width="496" alt="Screen Shot 2021-07-26 at 2 44 36 PM" src="https://user-images.githubusercontent.com/5148596/127043907-13b7e8f6-ae44-49f5-8fed-149ef029f8e0.png">
