### PR TITLE
feat(repo-form): route to org-listing if no repo specified

### DIFF
--- a/src/components/repo-form.tsx
+++ b/src/components/repo-form.tsx
@@ -13,7 +13,7 @@ const initialValues: Repo = {
 
 const validationSchema = object().shape({
   owner: string().required("Please enter a repository owner"),
-  name: string().required("Please enter a repository name"),
+  name: string().optional(),
 });
 
 function RepoFormComponent(props: FormikProps<Repo>) {
@@ -106,7 +106,7 @@ export function RepoForm() {
       validateOnBlur={false}
       validateOnChange={false}
       onSubmit={(values) => {
-        history.push(`/${values.owner}/${values.name}`);
+        history.push(`/${values.owner}/` + (values.name || ''))
       }}
     />
   );


### PR DESCRIPTION
This follows on from #26, allowing the user to just specify the org at the repo form. This directs the user to the org-listing page.

https://user-images.githubusercontent.com/10572368/127763119-d9c1c89c-6f38-4499-bfdc-688cbf61b938.mov



This PR is also related to #24 