### PR TITLE
fix(query): use `replaceIn` to avoid mangling browser history

### DIFF
--- a/src/components/json-detail-container.tsx
+++ b/src/components/json-detail-container.tsx
@@ -42,7 +42,7 @@ export function JSONDetail(props: JSONDetailProps) {
           query.tab && data.find((d) => d.key === query.tab)
             ? query.tab
             : (data.find((d) => d.key) || {}).key;
-        setQuery({ tab });
+        setQuery({ tab }, "replaceIn");
       },
     }
   );
@@ -89,11 +89,14 @@ export function JSONDetail(props: JSONDetailProps) {
       return;
     }
 
-    setQuery({
-      sort: newState.sort.join(","),
-      stickyColumnName: newState.stickyColumnName,
-      filters: encodeFilterString(newState.filters),
-    });
+    setQuery(
+      {
+        sort: newState.sort.join(","),
+        stickyColumnName: newState.stickyColumnName,
+        filters: encodeFilterString(newState.filters),
+      }, 
+      "replaceIn"
+    );
   };
 
   React.useEffect(() => {

--- a/src/components/repo-detail.tsx
+++ b/src/components/repo-detail.tsx
@@ -49,7 +49,7 @@ export function RepoDetail(props: RepoDetailProps) {
     {
       onSuccess: (data) => {
         if (!data.length) return;
-        setFilename(filename || data[0]);
+        setFilename(filename || data[0], "replaceIn");
       },
     }
   );
@@ -73,10 +73,10 @@ export function RepoDetail(props: RepoDetailProps) {
                   duration: 4000,
                 }
               );
-              setSelectedSha(mostRecentCommitSha);
+              setSelectedSha(mostRecentCommitSha, "replaceIn");
             }
           } else {
-            setSelectedSha(mostRecentCommitSha);
+            setSelectedSha(mostRecentCommitSha, "replaceIn");
           }
         }
       },


### PR DESCRIPTION
To ensure that the user retains a cleaner history of browsing
through Flat Viewer, set query parameters with `replaceIn` when:

repo-detail:
- File/commit metadata is loaded

json-detail-container:
- A file is loaded and a tab chosen
- `onGridChange()` is invoked

The latter bears noting, as this means we will no longer retain
a user's history of manipulating the grid. Given that `onGridChange()`
is invoked when data is loaded into the grid, we think that ensuring
a cleaner overall history is more important to the user than retaining
the specific click history for grid manipuation, which the user may
find difficult to follow anyway.