### PR TITLE
Simplify the download data from github apis

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -159,24 +159,13 @@ export async function fetchDataFile(params: FileParamsWithSHA) {
   //     ).auth(`token ${cachedPat}`)
   //   :
 
-  let res;
-  const text = await wretch(
-    `https://raw.githubusercontent.com/${owner}/${name}/${sha}/${filename}`
-  )
+  const res = await githubWretch
+    .url(`/repos/${owner}/${name}/contents/${filename}?ref=${sha}`)
     .get()
-    .notFound(async () => {
-      if (cachedPat) {
-        const data = await githubWretch
-          .url(`/repos/${owner}/${name}/contents/${filename}`)
-          .get()
-          .json();
-        const content = atob(data.content);
-        return content;
-      } else {
-        throw new Error("Data file not found");
-      }
-    })
-    .text();
+    .json();
+
+  const text =await  wretch(res.download_url).get().text()
+
 
   let data: any;
   try {


### PR DESCRIPTION
closes #41 
- use response `download_url` not base-encoded string which didn't allow when response greater than 1MB